### PR TITLE
Name columns for lexicon_nrc_vad.R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # textdata (development version)
 
+* Fixed bug where `lexicon_nrc_vad()` didn't have column names. (#53)
+
 # textdata 0.4.4
 
 * Update path to correctly path source for NRC lexicon.

--- a/R/lexicon_nrc_vad.R
+++ b/R/lexicon_nrc_vad.R
@@ -93,13 +93,9 @@ process_nrc_vad <- function(folder_path, name_path) {
     folder_path,
     "NRC-VAD-Lexicon-Aug2018Release/NRC-VAD-Lexicon.txt"
   ),
-  col_types = cols(
-    Word = col_character(),
-    Valence = col_double(),
-    Arousal = col_double(),
-    Dominance = col_double()
-  )
-  )
+  col_names = FALSE, 
+  show_col_types = FALSE) |>
+  setNames(c("Word", "Valence", "Arousal", "Dominance"))
 
   write_rds(data, name_path)
 }


### PR DESCRIPTION
Adds missing column names, to close #53 